### PR TITLE
fix: improve issue card UI based on given suggestions

### DIFF
--- a/app/components/repo-components/IssueCard.tsx
+++ b/app/components/repo-components/IssueCard.tsx
@@ -7,7 +7,8 @@ import {
 } from '@/app/components/ui/card';
 import type { IssuesData } from '@/app/store/useRepositoryStore';
 import { cn } from '@/lib/utils';
-import { Code, ExternalLink, GitPullRequest, Star, Tag } from 'lucide-react';
+import { color } from 'framer-motion';
+import { Code, Coins, ExternalLink, GitPullRequest } from 'lucide-react';
 import Link from 'next/link';
 import React from 'react';
 
@@ -51,25 +52,24 @@ const IssueCard = (props: IssuesData) => {
       <div className="relative z-10">
         <CardHeader className="p-4 sm:p-5 pb-2 border-b border-white/30">
           <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-2">
-            <CardTitle className="group mb-0 flex items-center font-semibold text-base sm:text-lg">
-              <span className="mr-2 line-clamp-2 text-gray-800 transition-colors duration-200">
-                {title}
-              </span>
+            <CardTitle className="group mb-0 flex-grow min-w-0 font-semibold text-base sm:text-lg">
               <Link
                 href={url}
                 passHref
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-gray-600 hover:text-gray-500 focus:text-gray-500 transition-colors duration-200"
+                className="flex items-center gap-1 text-gray-600 hover:text-gray-500 focus:text-gray-500 transition-colors duration-200"
                 aria-label={`Open issue "${title}" in a new tab`}
               >
+                <span className="text-gray-800 truncate">{title}</span>
                 <ExternalLink
-                  className="h-4 w-4 transition-transform duration-200 hover:scale-110"
+                  className="h-4 w-4 shrink-0 transition-transform duration-200 hover:scale-110"
                   aria-hidden="true"
                 />
               </Link>
             </CardTitle>
-            <div className="flex flex-shrink-0 gap-2">
+
+            <div className="flex flex-shrink-0 gap-2 sm:ml-4">
               <Badge
                 className={`${
                   difficultyColorMap[difficulty] ||
@@ -81,14 +81,10 @@ const IssueCard = (props: IssuesData) => {
               </Badge>
               {multiplierActive && multiplierValue && (
                 <Badge
-                  className="bg-white/40 border-white/40 text-gray-800 text-xs sm:text-sm backdrop-blur-sm px-3 py-1.5 hover:bg-white/50 focus:bg-white/50 transition-all duration-200"
+                  className="transition-all scale-[1.05] bg-yellow-100 border-yellow-300 text-yellow-800 text-xs sm:text-sm font-medium px-2 py-1.5 backdrop-blur-sm"
                   aria-label={`Multiplier: ${multiplierValue}x`}
                 >
-                  <Star
-                    className="mr-1.5 h-4 w-4 text-gray-600"
-                    aria-hidden="true"
-                  />
-                  {multiplierValue}x
+                  ⚡{multiplierValue}x Multiplier
                 </Badge>
               )}
             </div>
@@ -141,15 +137,16 @@ const IssueCard = (props: IssuesData) => {
                 className="flex items-center group"
                 aria-label={`Bounty: ${effectiveBounty} points`}
               >
-                <Tag
+                <Coins
                   className={cn(
-                    'mr-1.5 h-4 w-4 text-gray-600 transition-colors duration-200',
+                    'mr-1.5 h-5 w-5 text-gray-600 transition-colors duration-200',
                   )}
+                  color="var(--color-orange-400)"
                   aria-hidden="true"
                 />
                 <span
                   className={cn(
-                    'font-semibold text-sm sm:text-base text-gray-800 transition-all duration-200',
+                    'font-extrabold text-base sm:text-lg text-orange-400 transition-all duration-200',
                   )}
                 >
                   {effectiveBounty}
@@ -165,28 +162,26 @@ const IssueCard = (props: IssuesData) => {
                     </span>
                   )}
               </div>
-
               {isClaimed ? (
-                <Badge
-                  className="bg-white/40 border-white/40 text-gray-800 text-xs sm:text-sm transition-all duration-200 backdrop-blur-sm px-3 py-1.5 hover:bg-white/50 focus:bg-white/50"
-                  aria-label={
-                    claimedByList.length > 0
-                      ? `Claimed by ${claimedByList[0]}`
-                      : 'Claimed'
-                  }
-                >
-                  <span className="flex items-center">
-                    {claimedByList.length > 0 && (
-                      <span className="mr-1.5 font-normal">
-                        @{claimedByList[0]}
-                      </span>
-                    )}
-                    <span className="font-medium">Claimed</span>
-                  </span>
-                </Badge>
+                <div className="flex items-center flex-wrap gap-2">
+                  {claimedByList.slice(0, 2).map((user, idx) => (
+                    <Badge
+                      key={user}
+                      className="bg-white/40 border-white/40 text-gray-800 text-xs sm:text-sm px-3 py-1.5 backdrop-blur-sm"
+                      aria-label={`Claimed by ${user}`}
+                    >
+                      @{user}
+                    </Badge>
+                  ))}
+                  {claimedByList.length > 2 && (
+                    <Badge className="bg-gray-200 text-gray-700 text-xs px-2 py-1.5">
+                      +{claimedByList.length - 2} more
+                    </Badge>
+                  )}
+                </div>
               ) : (
                 <Badge
-                  className="bg-white/40 border-white/40 text-gray-800 text-xs sm:text-sm transition-all duration-200 backdrop-blur-sm px-3 py-1.5 hover:bg-white/50 focus:bg-white/50"
+                  className="bg-white/40 border-white/40 text-gray-800 text-xs sm:text-sm px-3 py-1.5 backdrop-blur-sm"
                   aria-label="Issue is available"
                 >
                   Available

--- a/app/components/repo-components/RepoCard.tsx
+++ b/app/components/repo-components/RepoCard.tsx
@@ -16,7 +16,7 @@ const RepoCard = (props: ReposData) => {
       <div className="flex h-full flex-row items-center justify-between p-4 sm:p-5">
         <div>
           <CardHeader className="p-0 pb-2 border-b border-white/30">
-            <div className="flex flex-row items-center">
+            <div className="flex flex-row items-center ">
               <CardTitle className="mb-0">
                 <a
                   href={props.url}
@@ -25,11 +25,11 @@ const RepoCard = (props: ReposData) => {
                   rel="noopener noreferrer"
                 >
                   <Github
-                    className="hidden md:block mr-2 h-5 w-5"
+                    className="hidden md:block mr-3 h-5 w-5 flex-shrink-0"
                     color="#4B5563"
                     aria-hidden="true"
                   />
-                  {props.name}
+                  <span className="line-clamp-2 text-left">{props.name}</span>
                 </a>
               </CardTitle>
             </div>

--- a/app/repo/page.tsx
+++ b/app/repo/page.tsx
@@ -391,7 +391,7 @@ const ReposPage = () => {
             />
             Issues
             {selectedRepo && (
-              <span className="ml-2 text-lg text-gray-700">
+              <span className="ml-2 text-lg text-gray-700 line-clamp-1">
                 - {selectedRepo.name}
               </span>
             )}

--- a/app/store/useRepositoryStore.ts
+++ b/app/store/useRepositoryStore.ts
@@ -39,7 +39,7 @@ export interface ReposData {
 export const tempRepos: ReposData[] = [
   {
     id: 'repoA',
-    name: 'Fantastic Frontend Project',
+    name: 'A Very Very Very Very Very Very Very Very Very Very Long Name for a Repository',
     url: 'https://github.com/frontend-dev/fantastic-app',
     maintainerUsernames: ['ui_master', 'react_ninja'],
     description:
@@ -81,13 +81,21 @@ export const tempRepos: ReposData[] = [
       },
       {
         id: 'issueA-2',
-        title: 'Fix layout issue on mobile',
+        title:
+          'A very very very very very very long issue title that goes on and on and on and on and on and on and on and on',
         url: 'https://github.com/frontend-dev/fantastic-app/issues/2',
         language: ['CSS'],
         bounty: 50,
         difficulty: 'Easy',
         isClaimed: true,
-        claimedByList: ['css_expert'],
+        claimedByList: [
+          'css_expert',
+          'mobile_dev',
+          'ui_guru',
+          'react_enthusiast',
+          'frontend_lover',
+          'web_dev',
+        ],
         multiplierActive: false,
         multiplierValue: null,
         completionStatus: true,


### PR DESCRIPTION
This PR improves the UI of the `IssueCard` component and the repositories page:

### Changes Made

- Long issue titles are now truncated with an ellipsis to prevent overflow.
- The entire issue title is now clickable, directing users to the corresponding GitHub issue.
- Replaced the bounty multiplier symbol from stars to a lightning ⚡ icon.
- The claimed-by list displays the first two participants; additional people are summarized with a “+x more” badge.
- Added a coins icon to highlight the updated bounty value when a multiplier is applied.

**I’m looking for suggestions on better ways to display the updated bounty points to make the upgrade more obvious and visually appealing.**

### Screenshot
![image](https://github.com/user-attachments/assets/916d5ff4-53e3-44dd-a13d-36d221b538c9)

